### PR TITLE
add optional monitoring setup (prometheus, monero-exporter, grafana)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ no particular order
 - add [xmrig](https://github.com/xmrig/xmrig) and [xmrig-proxy](https://github.com/xmrig/xmrig-proxy)
 - add merchant software. Maybe BTCPayServer, [MoneroPay](https://github.com/moneropay/moneropay), [HotShop](https://github.com/CryptoGrampy/HotShop)
 - add [Monero Light Wallet Server](https://github.com/vtnerd/monero-lws)
-- add [monerod-exporter](https://github.com/hundehausen/monerod-exporter) for Prometheus
 - add [Onion Monero Blockchain Explorer](https://github.com/moneroexamples/onion-monero-blockchain-explorer) (a Monero block explorer without JavaScript)
+- add Gitea (a self-hosted Git service) to mirror the Monero repositories
 
 ## Donations
 If you find this project useful, please consider donating to the following address:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "monero-suite",
   "description": "Build your personal docker-compose.yml file for Monero services.",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/components/BashPreview.tsx
+++ b/src/app/components/BashPreview.tsx
@@ -19,14 +19,16 @@ const baseBashCommands = [
   "",
   "# Allow SSH access",
   "sudo ufw allow ssh",
+  "",
+  "# Create monero-suite folder",
+  "mkdir -p monero-suite",
+  "cd monero-suite",
 ];
 
 const finalBashCommands = [
   "# Enable UFW",
   "sudo ufw enable",
   "",
-  "# change directory to where the docker-compose.yml file is located",
-  "cd ~/monero-suite",
   "# finally, start the containers with:",
   "docker compose up -d",
 ];

--- a/src/app/components/Selection.tsx
+++ b/src/app/components/Selection.tsx
@@ -19,6 +19,8 @@ const Selection = ({ services, stateFunctions }: SelectionProps) => {
   const {
     isMoneroPublicNode,
     setIsMoneroPublicNode,
+    moneroNodeDomain,
+    setMoneroNodeDomain,
     isPrunedNode,
     setIsPrunedNode,
     p2PoolMode,
@@ -30,15 +32,19 @@ const Selection = ({ services, stateFunctions }: SelectionProps) => {
     isXmrig,
     setIsXmrig,
     isMoneroblock,
-    isMonitoring,
-    grafanaDomain,
-    setGrafanaDomain,
-    setIsMonitoring,
     setIsMoneroblock,
+    moneroBlockDomain,
+    setMoneroBlockDomain,
     isMoneroblockLogging,
     setIsMoneroblockLogging,
     isOnionMoneroBlockchainExplorer,
     setIsOnionMoneroBlockchainExplorer,
+    onionMoneroBlockchainExplorerDomain,
+    setOnionMoneroBlockchainExplorerDomain,
+    isMonitoring,
+    setIsMonitoring,
+    grafanaDomain,
+    setGrafanaDomain,
     isTor,
     setIsTor,
     isWatchtower,
@@ -47,12 +53,6 @@ const Selection = ({ services, stateFunctions }: SelectionProps) => {
     setIsAutoheal,
     isTraefik,
     setIsTraefik,
-    moneroNodeDomain,
-    setMoneroNodeDomain,
-    moneroBlockDomain,
-    setMoneroBlockDomain,
-    onionMoneroBlockchainExplorerDomain,
-    setOnionMoneroBlockchainExplorerDomain,
   } = stateFunctions;
 
   const p2poolPayoutAddressError = () => {
@@ -313,18 +313,6 @@ const Selection = ({ services, stateFunctions }: SelectionProps) => {
         onChange={(event) => setIsTor(event.currentTarget.checked)}
       />
       <Checkbox
-        checked={isWatchtower}
-        label={
-          <ExplainingLabel
-            label="Watchtower"
-            explanation={services["watchtower"].description}
-          />
-        }
-        labelPosition="left"
-        size="lg"
-        onChange={(event) => setIsWatchtower(event.currentTarget.checked)}
-      />
-      <Checkbox
         checked={isMonitoring}
         label={
           <ExplainingLabel
@@ -349,6 +337,18 @@ const Selection = ({ services, stateFunctions }: SelectionProps) => {
           </Input.Wrapper>
         </>
       )}
+      <Checkbox
+        checked={isWatchtower}
+        label={
+          <ExplainingLabel
+            label="Watchtower"
+            explanation={services["watchtower"].description}
+          />
+        }
+        labelPosition="left"
+        size="lg"
+        onChange={(event) => setIsWatchtower(event.currentTarget.checked)}
+      />
       <Checkbox
         checked={isAutoheal}
         label={

--- a/src/app/components/Selection.tsx
+++ b/src/app/components/Selection.tsx
@@ -30,6 +30,10 @@ const Selection = ({ services, stateFunctions }: SelectionProps) => {
     isXmrig,
     setIsXmrig,
     isMoneroblock,
+    isMonitoring,
+    grafanaHostname,
+    setGrafanaHostname,
+    setIsMonitoring,
     setIsMoneroblock,
     isMoneroblockLogging,
     setIsMoneroblockLogging,
@@ -320,6 +324,31 @@ const Selection = ({ services, stateFunctions }: SelectionProps) => {
         size="lg"
         onChange={(event) => setIsWatchtower(event.currentTarget.checked)}
       />
+      <Checkbox
+        checked={isMonitoring}
+        label={
+          <ExplainingLabel
+            label="Monitoring"
+            explanation={services["monitoring"].description}
+          />
+        }
+        labelPosition="left"
+        size="lg"
+        onChange={(event) => setIsMonitoring(event.currentTarget.checked)}
+      />
+      {isMonitoring === true && (
+        <>
+          <Input.Wrapper
+                label="Grafana Hostname"
+                description="Change to desired URL if accessing externally (https://yourdomain.tld)"
+              >
+                <Input
+                  value={grafanaHostname}
+                  onChange={(e) => setGrafanaHostname(e.currentTarget.value)}
+                />
+          </Input.Wrapper>
+        </>
+      )}
       <Checkbox
         checked={isAutoheal}
         label={

--- a/src/app/components/Selection.tsx
+++ b/src/app/components/Selection.tsx
@@ -31,8 +31,8 @@ const Selection = ({ services, stateFunctions }: SelectionProps) => {
     setIsXmrig,
     isMoneroblock,
     isMonitoring,
-    grafanaHostname,
-    setGrafanaHostname,
+    grafanaDomain,
+    setGrafanaDomain,
     setIsMonitoring,
     setIsMoneroblock,
     isMoneroblockLogging,
@@ -339,13 +339,13 @@ const Selection = ({ services, stateFunctions }: SelectionProps) => {
       {isMonitoring === true && (
         <>
           <Input.Wrapper
-                label="Grafana Hostname"
-                description="Change to desired URL if accessing externally (https://yourdomain.tld)"
-              >
-                <Input
-                  value={grafanaHostname}
-                  onChange={(e) => setGrafanaHostname(e.currentTarget.value)}
-                />
+            label="Grafana Hostname"
+            description="Change to desired URL if accessing externally (https://yourdomain.tld)"
+          >
+            <Input
+              value={grafanaDomain}
+              onChange={(e) => setGrafanaDomain(e.currentTarget.value)}
+            />
           </Input.Wrapper>
         </>
       )}

--- a/src/hooks/use-services.ts
+++ b/src/hooks/use-services.ts
@@ -42,6 +42,8 @@ export const useServices = () => {
     onionMoneroBlockchainExplorerDomain,
     setOnionMoneroBlockchainExplorerDomain,
   ] = useState("");
+  const [isMonitoring, setIsMonitoring] = useState(false);
+  const [grafanaDomain, setGrafanaDomain] = useState("grafana.monerosuite.org");
   const [isAutoheal, setIsAutoheal] = useState(false);
   const [isXmrig, setIsXmrig] = useState(false);
   const [isTraefik, setIsTraefik] = useState(false);
@@ -62,6 +64,8 @@ sudo ufw allow 18080/tcp 18089/tcp`
             : undefined,
           volumes: {
             bitmonero: {},
+            grafana: {},
+            prometheus: {},
           },
           code: {
             monerod: {
@@ -85,6 +89,9 @@ sudo ufw allow 18080/tcp 18089/tcp`
               command: [
                 "--rpc-restricted-bind-ip=0.0.0.0",
                 "--rpc-restricted-bind-port=18089",
+                "--rpc-bind-ip=0.0.0.0",
+                "--rpc-bind-port=18083", // unrestricted port for internal use
+                "--confirm-external-bind",
                 "--enable-dns-blocklist",
                 "--no-igd",
                 "--out-peers=50",
@@ -296,6 +303,103 @@ sudo ufw allow 3333/tcp`
             },
           },
         },
+        monitoring: {
+          name: "Monitoring",
+          description:
+            "Monitoring with Prometheus and Grafana: see your node stats visualized in graphs. See on a map where your peers are located.",
+          checked: isMonitoring,
+          required: false,
+          volumes: {
+            grafana: {},
+            prometheus: {},
+          },
+          bash: `
+# Download default Prometheus and Grafana configs/dashboards
+mkdir -p monitoring/grafana/dashboards monitoring/grafana/provisioning/{dashboards,datasources} monitoring/prometheus 
+wget -O monitoring/prometheus/config.yaml https://raw.githubusercontent.com/lalanza808/docker-monero-node/master/monitoring/prometheus/config.yaml
+wget -O monitoring/grafana/grafana.ini https://raw.githubusercontent.com/lalanza808/docker-monero-node/master/monitoring/grafana/grafana.ini
+wget -O monitoring/grafana/dashboards/node_stats.json https://raw.githubusercontent.com/lalanza808/docker-monero-node/master/monitoring/grafana/dashboards/node_stats.json
+wget -O monitoring/grafana/provisioning/dashboards/all.yaml https://raw.githubusercontent.com/lalanza808/docker-monero-node/master/monitoring/grafana/provisioning/dashboards/all.yaml
+wget -O monitoring/grafana/provisioning/datasources/all.yaml https://raw.githubusercontent.com/lalanza808/docker-monero-node/master/monitoring/grafana/provisioning/datasources/all.yaml
+
+# Optionally customize the Monitoring deployment with environment variables
+cd monitoring
+touch .env
+echo GF_LOG_LEVEL=info >> .env
+echo GF_USERS_ALLOW_SIGN_UP=false >> .env
+echo GF_USERS_ALLOW_ORG_CREATE=false >> .env
+echo GF_AUTH_ANONYMOUS_ENABLED=true >> .env
+echo GF_AUTH_BASIC_ENABLED=false >> .env
+echo GF_AUTH_DISABLE_LOGIN_FORM=true >> .env
+echo GF_SECURITY_ADMIN_PASSWORD=admin >> .env
+echo GF_SECURITY_ADMIN_USER=admin >> .env
+# nano .env
+`,
+          code: {
+            prometheus: {
+              image: "prom/prometheus:latest",
+              container_name: "prometheus",
+              restart: "unless-stopped",
+              command: [
+                "--config.file=/etc/prometheus/config.yaml",
+                "--storage.tsdb.path=/prometheus",
+                "--storage.tsdb.retention.time=${PROM_RETENTION:-360d}",
+              ],
+              volumes: [
+                "prometheus:/prometheus",
+                "./monitoring/prometheus/config.yaml:/etc/prometheus/config.yaml:ro",
+              ],
+            },
+            exporter: {
+              image: "lalanza808/monerod_exporter:latest",
+              container_name: "monerod_exporter",
+              restart: "unless-stopped",
+              command: "--monero-addr=http://monerod:18083",
+            },
+            grafana: {
+              image: "grafana/grafana:latest",
+              container_name: "grafana",
+              user: "1000",
+              command: "-config=/etc/grafana/grafana.ini",
+              restart: "unless-stopped",
+              ports: ["127.0.0.1:${GF_PORT:-3000}:3000"],
+              volumes: [
+                "grafana:/var/lib/grafana",
+                "./monitoring/grafana/grafana.ini:/etc/grafana/grafana.ini:ro",
+                "./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro",
+                "./monitoring/grafana/dashboards:/var/lib/grafana/dashboards:ro",
+              ],
+              environment: {
+                HOSTNAME: "grafana",
+                GF_SERVER_ROOT_URL: `https://${grafanaDomain}`,
+                GF_ANALYTICS_REPORTING_ENABLED: "false",
+                GF_ANALYTICS_CHECK_FOR_UPDATES: "false",
+                GF_LOG_LEVEL: "${GF_LOG_LEVEL:-error}",
+                GF_USERS_ALLOW_SIGN_UP: "${GF_USERS_ALLOW_SIGN_UP:-false}",
+                GF_USERS_ALLOW_ORG_CREATE:
+                  "${GF_USERS_ALLOW_ORG_CREATE:-false}",
+                GF_AUTH_ANONYMOUS_ENABLED: "${GF_AUTH_ANONYMOUS_ENABLED:-true}",
+                GF_AUTH_BASIC_ENABLED: "${GF_AUTH_BASIC_ENABLED:-false}",
+                GF_AUTH_DISABLE_LOGIN_FORM:
+                  "${GF_AUTH_DISABLE_LOGIN_FORM:-true}",
+                GF_SECURITY_ADMIN_PASSWORD:
+                  "${GF_SECURITY_ADMIN_PASSWORD:-admin}",
+                GF_SECURITY_ADMIN_USER: "${GF_SECURITY_ADMIN_USER:-admin}",
+              },
+            },
+          },
+          labels: isTraefik
+            ? {
+                "traefik.enable": "true",
+                "traefik.http.routers.monitoring.rule": `Host(\`${grafanaDomain}\`)`,
+                "traefik.http.routers.monitoring.entrypoints": "websecure",
+                "traefik.http.routers.monitoring.tls.certresolver":
+                  "monerosuite",
+                "traefik.http.services.monitoring.loadbalancer.server.port":
+                  "31312",
+              }
+            : undefined,
+        },
         autoheal: {
           name: "Autoheal",
           description:
@@ -374,8 +478,10 @@ sudo ufw allow 3333/tcp`
       isMoneroblock,
       isMoneroblockLogging,
       isOnionMoneroBlockchainExplorer,
+      grafanaDomain,
       isTor,
       isWatchtower,
+      isMonitoring,
       isAutoheal,
       isTraefik,
       moneroNodeDomain,
@@ -409,6 +515,10 @@ sudo ufw allow 3333/tcp`
       setIsTor,
       isWatchtower,
       setIsWatchtower,
+      isMonitoring,
+      setIsMonitoring,
+      grafanaDomain,
+      setGrafanaDomain,
       isAutoheal,
       setIsAutoheal,
       isTraefik,


### PR DESCRIPTION
cool project. this PR includes extra services for "Monitoring" selection with some open source tools.

prometheus and grafana are pretty much off the shelf using their container images.

the exporter is from `github.com/cirocosta/monero-exporter` - I used this dockerfile from my own project: https://github.com/lalanza808/docker-monero-node/blob/master/dockerfiles/monerod_exporter

the files fetched from wget are from that same project for the default prom and graf configs/dashboards: https://github.com/lalanza808/docker-monero-node/tree/master/files

The finished product looks like this https://singapore.node.xmr.pm

I did some light testing and appears to work as expected.